### PR TITLE
Minor cleanup of config isDev

### DIFF
--- a/config-prod.js
+++ b/config-prod.js
@@ -1,5 +1,4 @@
 exports = module.exports = {
-  isDev: true,
   logging: true,
   server: {
     secure: false, // false=ws, true=wss

--- a/config.js
+++ b/config.js
@@ -1,5 +1,4 @@
 exports = module.exports = {
-  isDev: true,
   logging: true,
   server: {
     secure: false, // false=ws, true=wss

--- a/src/utils.js
+++ b/src/utils.js
@@ -10,7 +10,7 @@ dotEnv.config();
  * @constructor
  */
 exports.GetCertOptions = function () {
-  if (config.isDev) {
+  if (!config.server.secure) {
     return {
       secure: false,
     };


### PR DESCRIPTION
As i understand usage of `config.isDev` in GetCertOptions is unintended, `config.server.secure` should be used there (as specified in comments). This change makes `config.isDev` obsolete, it isn't used anywhere else, so I removed it