### PR TITLE
Handle invalid roomId in holdem.js

### DIFF
--- a/holdem.js
+++ b/holdem.js
@@ -662,12 +662,6 @@ function getRankings(connectionId, socketKey) {
       }
     }).catch(() => {
     });
-  } else {
-    responseArray.key = "getRankingsResult";
-    responseArray.code = 500;
-    // @TODO crash on players[connectionId].connection === null
-    players[connectionId].connection.sendText(JSON.stringify(responseArray));
-    cleanResponseArray();
   }
 }
 
@@ -731,12 +725,6 @@ function getPlayerChartData(connectionId, socketKey) {
       }
     }).catch(() => {
     });
-  } else {
-    responseArray.key = "getPlayerChartDataResult";
-    responseArray.code = 500;
-    // @TODO crash on players[connectionId].connection === null
-    players[connectionId].connection.sendText(JSON.stringify(responseArray));
-    cleanResponseArray();
   }
 }
 
@@ -754,12 +742,6 @@ function getSelectedPlayerChartData(connectionId, socketKey, playerId) {
       }
     }).catch(() => {
     });
-  } else {
-    // @TODO crash on players[connectionId].connection === null
-    responseArray.key = "getPlayerChartDataResult";
-    responseArray.code = 500;
-    players[connectionId].connection.sendText(JSON.stringify(responseArray));
-    cleanResponseArray();
   }
 }
 


### PR DESCRIPTION
Custom clients may send invalid `roomId`, so it will throw `TypeError: rooms[roomId] is undefined` and crash the server app.

Since there are also repetitive checks of `players[connectionId].connection !== null` and `players[connectionId].socketKey === socketKey`, I would like to implement the fix by introducing helper function that will check connection and also check `roomId` when it is needed.

To implement it correctly I would like to hear your feedback:
1. There are places where you only checking `players[connectionId].connection` but not checking `socketKey`. [L543](https://github.com/norkator/poker-pocket-backend/blob/2d053d3b656e1eee1f91792711a37069456803bf/holdem.js#L543), [L560](https://github.com/norkator/poker-pocket-backend/blob/2d053d3b656e1eee1f91792711a37069456803bf/holdem.js#L560), [L615](https://github.com/norkator/poker-pocket-backend/blob/2d053d3b656e1eee1f91792711a37069456803bf/holdem.js#L615) etc. Is it intended? Maybe we should check `socketKey` there too?
2. There are `else` branches which always throw because there is no `players[connectionId].connection.sendText` when `players[connectionId].connection === null`. [L745](https://github.com/norkator/poker-pocket-backend/blob/2d053d3b656e1eee1f91792711a37069456803bf/holdem.js#L745), [L769](https://github.com/norkator/poker-pocket-backend/blob/2d053d3b656e1eee1f91792711a37069456803bf/holdem.js#L769). How should I handle these `else` branches?